### PR TITLE
add wrapper to renew_cert.sh : check expiry

### DIFF
--- a/scripts/renew_cert.sh
+++ b/scripts/renew_cert.sh
@@ -1,29 +1,117 @@
 #!/usr/bin/env bash
 
+MAVEN_BINARY="/usr/local/apache-maven/apache-maven-3.6.3/bin/mvn"
 PROJECT_HOME="/home/ec2-user/pdb-annotation"
 CERTBOT_HOME="/home/ec2-user"
 DOMAIN_NAME="g2s.genomenexus.org"
 WEBROOT="/usr/share/tomcat8/webapps/ROOT"
 CERT_CA_NAME="g2s"
 CERT_PASSWORD="123456"
+MAX_WAIT_SHUTDOWN_SEC=8
+MAX_WAIT_STARTUP_SEC=8
+POST_STARTUP_WAIT_SEC=3
+RECOVERY_ATTEMPT_WAIT_SEC=60
 
-# stop spring boot
-# TODO this assumes that we don't have any java processes other than initiated by spring-boot:run, we should probably be more specific
-pkill -f "java"
+function start_up_spring_boot() {
+    cd $PROJECT_HOME/pdb-alignment-web
+    $MAVEN_BINARY spring-boot:run >/dev/null 2>&1 &
+}
 
-# start tomcat8 for renewal process
-sudo service tomcat8 start
+function kill_spring_boot() {
+    # TODO this assumes that we don't have any java processes other than initiated by spring-boot:run, we should probably be more specific
+    pkill -f "java"
+}
 
-# run certbot to generate a new cert
-sudo $CERTBOT_HOME/certbot-auto certonly --webroot --webroot-path $WEBROOT --domains $DOMAIN_NAME
+function spring_boot_is_now_running() {
+    pgrep -f "java" > /dev/null 2>&1
+}
 
-# export the cert
-sudo openssl pkcs12 -export -in /etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem -inkey /etc/letsencrypt/live/$DOMAIN_NAME/privkey.pem -out keystore.p12 -name tomcat -CAfile /etc/letsencrypt/live/$DOMAIN_NAME/chain.pem -caname $CERT_CA_NAME -passout pass:$CERT_PASSWORD
+function start_tomcat() {
+    sudo service tomcat8 start
+}
 
-# copy credential to the project
-cp keystore.p12 $PROJECT_HOME/pdb-alignment-web/src/main/resources
+function kill_tomcat() {
+    sudo service tomcat8 stop
+}
 
-# stop tomcat8 and startup spring-boot
-sudo service tomcat8 stop
-cd $PROJECT_HOME/pdb-alignment-web
-mvn spring-boot:run &
+function tomcat_is_now_running() {
+    pgrep -f "tomcat" > /dev/null 2>&1
+}
+
+function shutdown_spring_boot_with_short_wait() {
+    kill_spring_boot
+    i=0
+    while spring_boot_is_now_running ; do
+        sleep 1
+        i=$((i+1))
+        if [ $i -ge $MAX_WAIT_SHUTDOWN_SEC ] ; then
+            echo "warning : spring boot was still running $MAX_WAIT_SHUTDOWN_SEC seconds after the shutdown attempt. Continuing anyway." >&2
+            break
+        fi
+    done
+}
+
+function start_up_tomcat_with_short_wait() {
+    start_tomcat
+    i=0
+    while ! tomcat_is_now_running ; do
+        sleep 1
+        i=$((i+1))
+        if [ $i -ge $MAX_WAIT_STARTUP_SEC ] ; then
+            echo "warning : tomcat was not running $MAX_WAIT_STARTUP_SEC seconds after the start up attempt. Continuing anyway." >&2
+            break
+        fi
+    done
+    sleep $POST_STARTUP_WAIT_SEC
+}
+
+function shutdown_tomcat_with_short_wait() {
+    kill_tomcat
+    i=0
+    while tomcat_is_now_running ; do
+        sleep 1
+        i=$((i+1))
+        if [ $i -ge $MAX_WAIT_SHUTDOWN_SEC ] ; then
+            echo "warning : tomcat was still running $MAX_WAIT_SHUTDOWN_SEC seconds after the shutdown attempt. Continuing anyway." >&2
+            break
+        fi
+    done
+}
+
+function renew_certificate() {
+    # run certbot to generate a new cert
+    sudo $CERTBOT_HOME/certbot-auto certonly --webroot --webroot-path $WEBROOT --domains $DOMAIN_NAME
+    # export the cert
+    sudo openssl pkcs12 -export -in /etc/letsencrypt/live/$DOMAIN_NAME/fullchain.pem -inkey /etc/letsencrypt/live/$DOMAIN_NAME/privkey.pem -out keystore.p12 -name tomcat -CAfile /etc/letsencrypt/live/$DOMAIN_NAME/chain.pem -caname $CERT_CA_NAME -passout pass:$CERT_PASSWORD
+    # copy credential to the project
+    cp -a keystore.p12 $PROJECT_HOME/pdb-alignment-web/src/main/resources
+}
+
+function start_up_spring_boot_with_recovery() {
+    start_up_spring_boot
+    sleep $RECOVERY_ATTEMPT_WAIT_SEC
+    if ! spring_boot_is_now_running ; then
+        echo "Warning : spring boot startup seems to have failed. Process is not running after $RECOVERY_ATTEMPT_WAIT_SEC seconds. Attempting emergency restart."
+        sleep $POST_STARTUP_WAIT_SEC
+        shutdown_spring_boot_with_short_wait
+        shutdown_tomcat_with_short_wait
+        sleep $POST_STARTUP_WAIT_SEC
+        start_up_spring_boot
+        sleep $POST_STARTUP_WAIT_SEC
+        if spring_boot_is_now_running ; then
+            echo "emergency restart seems to have succeeded."
+        else
+            echo "emergency restart seems to have failed."
+        fi
+    fi
+}
+
+function main() {
+    shutdown_spring_boot_with_short_wait
+    start_up_tomcat_with_short_wait
+    renew_certificate
+    shutdown_tomcat_with_short_wait
+    start_up_spring_boot_with_recovery
+}
+
+main

--- a/scripts/renew_cert_if_nerly_expired.sh
+++ b/scripts/renew_cert_if_nerly_expired.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+MAX_SEC_TO_EXPIRY_WITHOUT_WARNING=$((11*24*60*60)) # 11 days
+TMP_DIR="/tmp/g2s_check"
+G2S_HOSTNAME="g2s.genomenexus.org"
+RESPONSE_FILENAME="$TMP_DIR/g2s_cert_response.txt"
+PEM_FILENAME="$TMP_DIR/g2s_certs.pem"
+CERTIFICATE_TEXT_FILENAME="$TMP_DIR/cert.txt"
+RENEW_CERT_SCRIPT_FILEPATH="/home/ec2-user/renew_cert.sh"
+
+function make_tmp_dir_if_necessary() {
+    if ! [ -d "$TMP_DIR" ] ; then
+        if ! mkdir -p "$TMP_DIR" ; then
+            echo "Error : could not create tmp directory '$TMP_DIR'" >&2
+        exit 1
+        fi
+    fi
+}
+
+function request_certificate() {
+    if ! openssl s_client -showcerts -connect $G2S_HOSTNAME:443 < /dev/null > "$RESPONSE_FILENAME" 2> /dev/null ; then
+        echo "error : could not fetch certificate from server $G2S_HOSTNAME"
+        exit 1
+    fi
+}
+
+function trim_certificate() {
+    if ! sed -n -e '/-.BEGIN/,/-.END/ p' "$RESPONSE_FILENAME" > "$PEM_FILENAME" ; then
+        echo "error : could not extract pem content from response from $G2S_HOSTNAME response"
+        exit 1
+    fi
+}
+
+function extract_certificate_text() {
+    if ! openssl x509 -in "$PEM_FILENAME" -text > "$CERTIFICATE_TEXT_FILENAME" ; then
+        echo "error : pem content from $G2S_HOSTNAME is not in recognizable format"
+        exit 1
+    fi
+}
+
+function extract_expiration_date() {
+    unset cert_expiry_date
+    cert_expiry_date=$(grep -A1 "Not Before" "$CERTIFICATE_TEXT_FILENAME" | head -n 2 | grep "Not After" | sed "s/.*[ ]:[ ]//")
+    if [ -z "$cert_expiry_date" ] ; then
+        echo "error : could not locate expiration date (Not After) from $G2S_HOSTNAME"
+        exit 1
+    fi
+}
+
+function computes_seconds_until_expiration() {
+    unset sec_to_expiry
+    cert_expiry_sec_since_epoc=$(date --date="$cert_expiry_date" +%s)
+    current_sec_since_epoc=$(date +%s)
+    sec_to_expiry=$(( $cert_expiry_sec_since_epoc - $current_sec_since_epoc ))
+}
+
+function renew_cert_if_necessary() {
+    if [ "$sec_to_expiry" -lt "$MAX_SEC_TO_EXPIRY_WITHOUT_WARNING" ] ; then
+	date
+	echo "attempting to renew certificate"
+        $RENEW_CERT_SCRIPT_FILEPATH
+    fi
+}
+
+function clean_up() {
+    rm -f "$G2S_HOSTNAME" "$RESPONSE_FILENAME" "$PEM_FILENAME" "$CERTIFICATE_TEXT_FILENAME"
+}
+
+function main() {
+    make_tmp_dir_if_necessary
+    request_certificate
+    trim_certificate
+    extract_certificate_text
+    extract_expiration_date
+    computes_seconds_until_expiration
+    renew_cert_if_necessary
+    clean_up
+}
+
+main


### PR DESCRIPTION
- the wrapper script downloads and examines the expiration date of the cert. If the cert will expire in the next 11 days, renew_cert.sh is called
- renew_cert.sh has been enhanced with wait loops after starting and stopping web servers (spring boot for the app or tomcat for certbot). The wait loop will wait up to 8 seconds (max) for the services to complete start up or to complete shut down.
- renew_cert.sh also has been enhanced to attempt 1 "emergency restart" if the startup of the spring boot web app fails on the first try.
- this new approach allows a crontab entry which runs frequently (every 30 minutes?) rather than on particular days on which the certificate is expected to expire.